### PR TITLE
Allow injection of secrets through use of environment variables

### DIFF
--- a/CONFIGURE.md
+++ b/CONFIGURE.md
@@ -1,16 +1,27 @@
 # How to configure breakglass
 
-The config for Breakglass lives in a Kubernetes configmap in the file `K8s/breakglass-configmap.yaml` file. Take a look at `K8s/breakglass-configmap.yaml.example` for an example configuration. Al the breakglass settings are in `data > config`
+Breakglass is configured using a `Configmap` and a K8s `Secret`.
+
+The config for Breakglass lives in a Kubernetes configmap in the file `K8s/breakglass-configmap.yaml` file. Take a look at `K8s/breakglass-configmap.yaml.example` for an example configuration. All the breakglass settings are in `data > config`
+
+The secrets for Breakglass lives in a Kubernetes Secret in the file `K8s/breakglass-secret.yaml` file. Take a look at `K8s/breakglass-secret.yaml.example` for an example configuration.
+
+## GCP Service Account
+
+Breakglass needs access to the GCP Api using a service account that has the ability to manage permissions.
+
+```yaml
+GCP_CREDENTIALS: # encode using base64
+```
+
 
 ## OAuth Key
 
 Breakglass needs google OAuth to be configured to work, so be sure to include
 
 ```yaml
-OAuthClientId: 1234567890-XYZWVUTSRQP...
+OAUTH_CLIENT_ID: # encode using base64
 ```
-
-In `data > config > OAuthClientID: 123...`
 
 ## Global Settings
 
@@ -77,10 +88,10 @@ sql-server-1337:
       - https://DATABASE-MANAGERS-CHATROOM-HOOK/qwerty
 ```
 
-If you want to have email notifications you must get a [SendGrid API Key](https://signup.sendgrid.com/). You can get 100 emails a day for free. Include the key on the top level of the config as follows
+If you want to have email notifications you must get a [SendGrid API Key](https://signup.sendgrid.com/). You can get 100 emails a day for free. Include the key in the K8s Secret.
 
 ```yaml
-SendGridKey: SG.XYZABC...
+SENDGRID_KEY: # encode using base64
 ```
 
 `chatrooms` is a list of webhooks that point at specific Google Chat Spaces. Read about webhooks [here](https://developers.google.com/hangouts/chat/how-tos/webhooks).

--- a/K8s/breakglass-configmap.yaml.example
+++ b/K8s/breakglass-configmap.yaml.example
@@ -37,9 +37,3 @@ data:
         emails:
           - jtstille@uvm.edu
 
-    SendGridKey: SG.ABCXYZ
-    OAuthClientId: XXXXXXXXX.apps.googleusercontent.com
-    ServiceAccountKey: {
-        "type": "service_account",
-        ... Rest of JSON copied from key.json
-      }

--- a/K8s/breakglass-secret.yaml.example
+++ b/K8s/breakglass-secret.yaml.example
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: breakglass
+  namespace: breakglass
+data:
+  GCP_CREDENTIALS: # encode using base64
+  OAUTH_CLIENT_ID: # encode using base64
+  SENDGRID_KEY: # encode using base64
+

--- a/K8s/breakglass.yaml
+++ b/K8s/breakglass.yaml
@@ -21,6 +21,8 @@ spec:
           envFrom:
             - configMapRef:
                 name: breakglass-configmap
+            - secretRef:
+                name: breakglass
 ---
 apiVersion: v1
 kind: Service

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ BreakGlass is a tool that allows developers to temporarily escalate their own GC
    Now the project will be running, but you have not whitelisted the port on the OAuth, so it will not work as is. Ensure everything is working properly by forwarding the port to the pod
 
    ```
-   kubectl port-forward {Naem od pod that was created} 8080:8080
+   kubectl port-forward {Naem of pod that was created} 8080:8080
    ```
 
    Now navigate to `http://localhost:8080`

--- a/modules/breakglass-api/package.json
+++ b/modules/breakglass-api/package.json
@@ -15,7 +15,7 @@
     "express": "^4.17.1",
     "jsonwebtoken": "^8.5.1",
     "jwt-decode": "^2.2.0",
-    "parcel": "^1.12.4",
+    "parcel": "1.12.3",
     "yaml": "^1.10.0"
   },
   "devDependencies": {

--- a/modules/breakglass-api/src/getConf.ts
+++ b/modules/breakglass-api/src/getConf.ts
@@ -3,8 +3,13 @@ import YAML from "yaml";
 export function getConf() {
   //@ts-ignore
   const rawConf = process.env.config;
+
   if (rawConf) {
-    return YAML.parse(rawConf);
+    const parsedConfig = YAML.parse(rawConf);
+    parsedConfig["ServiceAccountKey"] = JSON.parse(process.env.GCP_CREDENTIALS);
+    parsedConfig["OAuthClientId"] = process.env.OAUTH_CLIENT_ID;
+    parsedConfig["SendGridKey"] = process.env.SENDGRID_KEY;
+    return parsedConfig;
   } else {
     throw new Error("NO CONFIG PROVIDED IN ENV");
   }

--- a/modules/breakglass-ui/package.json
+++ b/modules/breakglass-ui/package.json
@@ -12,7 +12,7 @@
     "axios": "^0.19.2",
     "bulma": "^0.8.2",
     "jwt-decode": "^2.2.0",
-    "parcel": "^1.12.4",
+    "parcel": "1.12.3",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-google-login": "^5.1.20",


### PR DESCRIPTION
This feature is to enable us to use gitops to manage the permission escalation configs.

I tried a few alternatives such as using an initcontainer to parse the secrets into a file. But the special characters of the gcp key were not compatible with the methods. 

The change to `parcel` is due to an error I experienced [recommended fix](https://github.com/parcel-bundler/parcel/issues/5943).

